### PR TITLE
Removing deprecated Gemnasium badge

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -32,6 +32,7 @@ engines:
   rubocop:
     enabled: true
     config: '.rubocop_cc.yml'
+    channel: 'rubocop-0-69'
 prepare:
   fetch:
   - url: "https://raw.githubusercontent.com/ManageIQ/guides/master/.rubocop_base.yml"

--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@
 [![Build Status](https://travis-ci.org/ManageIQ/log_decorator.svg)](https://travis-ci.org/ManageIQ/log_decorator)
 [![Code Climate](https://codeclimate.com/github/ManageIQ/log_decorator.svg)](https://codeclimate.com/github/ManageIQ/log_decorator)
 [![Test Coverage](https://codeclimate.com/github/ManageIQ/log_decorator/badges/coverage.svg)](https://codeclimate.com/github/ManageIQ/log_decorator/coverage)
-[![Dependency Status](https://gemnasium.com/ManageIQ/log_decorator.svg)](https://gemnasium.com/ManageIQ/log_decorator)
 [![Security](https://hakiri.io/github/ManageIQ/log_decorator/master.svg)](https://hakiri.io/github/ManageIQ/log_decorator/master)
 
 Acts as a proxy to a configurable underlying logging mechanism,


### PR DESCRIPTION
Functionality has been replaced by GitHub's dependency graph and security alerts.