### PR TITLE
cleanup .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
-sudo: false
 language: ruby
 cache: bundler
 rvm:
-  - "2.4"
   - "2.5"
   - "2.6"
   - "2.7"


### PR DESCRIPTION
we don't need sudo:false per https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration and we probably no longer need to support 2.4 either