### PR TITLE
Fix sporadic log_decorator failure due to log.level

### DIFF
--- a/spec/log_decorator_spec.rb
+++ b/spec/log_decorator_spec.rb
@@ -76,6 +76,10 @@ describe LogDecorator do
       TestLog.sio.reopen("")
     end
 
+    after do
+      TestClass1._log.level = Logger::DEBUG
+    end
+
     it "should log expected message from class method at DEBUG" do
       expect(TestClass1._log.debug?).to be true
       TestClass1.cmethod


### PR DESCRIPTION
Some specs change the shared _log.level to info causing other tests to fail when logging to debug.

Fixes https://github.com/ManageIQ/log_decorator/issues/19